### PR TITLE
fix: More Info OCR detection for new profile UI + anti-bot improvements

### DIFF
--- a/roktracker/kingdom/scanner.py
+++ b/roktracker/kingdom/scanner.py
@@ -11,6 +11,7 @@ import numpy as np
 from dummy_root import get_app_root
 from pathlib import Path
 from roktracker.utils.adb import *
+from roktracker.utils.exceptions import GovernorNotFoundError
 from roktracker.utils.general import *
 from roktracker.utils.ocr import *
 from roktracker.kingdom.additional_data import AdditionalData
@@ -197,10 +198,8 @@ class KingdomScanner:
 
         self.state_callback("Opening governor")
         # Open governor
-        self.adb_client.secure_adb_shell(
-            f"input tap 690 "
-            + str(self.get_gov_position(current_player, self.inactive_players))
-        )
+        gov_y = self.get_gov_position(current_player, self.inactive_players)
+        self.adb_client.secure_adb_tap((690, gov_y))
 
         wait_random_range(self.timings["gov_open"], self.max_random_delay)
 
@@ -224,7 +223,7 @@ class KingdomScanner:
             )
             check_more_info = ""
 
-            with PyTessBaseAPI(path=str(self.tesseract_path)) as api:
+            with PyTessBaseAPI(path=str(self.tesseract_path), psm=PSM.SINGLE_LINE) as api:
                 api.SetVariable("tessedit_char_whitelist", "MoreInfo")
                 api.SetImage(Image.fromarray(im_check_more_info))  # type: ignore (pylance is messed up)
                 check_more_info = api.GetUTF8Text()
@@ -258,9 +257,8 @@ class KingdomScanner:
                     )
                 else:
                     self.adb_client.secure_adb_shell(f"input swipe 690 605 690 540")
-                self.adb_client.secure_adb_shell(
-                    f"input tap 690 "
-                    + str(self.get_gov_position(current_player, self.inactive_players)),
+                self.adb_client.secure_adb_tap(
+                    (690, self.get_gov_position(current_player, self.inactive_players))
                 )
                 count += 1
                 wait_random_range(self.timings["gov_open"], self.max_random_delay)
@@ -269,7 +267,9 @@ class KingdomScanner:
                     if cont:
                         count = 0
                     else:
-                        break
+                        raise GovernorNotFoundError(
+                            "Could not open governor profile. Make sure the game is on the kingdom rankings screen (power or killpoints ranking)."
+                        )
             else:
                 gov_info = True
                 image_check = load_cv2_img(
@@ -537,10 +537,17 @@ class KingdomScanner:
                 break
 
             next_gov_to_scan = max(next_gov_to_scan + 1, i)
-            gov_data = self.scan_governor(
-                next_gov_to_scan,
-                track_inactives,
-            )
+            try:
+                gov_data = self.scan_governor(
+                    next_gov_to_scan,
+                    track_inactives,
+                )
+            except GovernorNotFoundError as e:
+                self.output_handler(str(e))
+                logging.log(logging.ERROR, str(e))
+                self.state_callback("Scan aborted")
+                data_handler.save()
+                return
 
             # Check for duplicate governor
             if data_handler.is_duplicate(to_int_check(gov_data.id)):

--- a/roktracker/utils/adb.py
+++ b/roktracker/utils/adb.py
@@ -110,8 +110,12 @@ class AdvancedAdbClient:
                 return result
         return result
 
-    def secure_adb_tap(self, position: Tuple[int, int]):
-        self.secure_adb_shell(f"input tap {position[0]} {position[1]}")
+    def secure_adb_tap(self, position: Tuple[int, int], jitter: int = 5):
+        import random
+        x = position[0] + random.randint(-jitter, jitter)
+        y = position[1] + random.randint(-jitter, jitter)
+        duration = random.randint(50, 150)
+        self.secure_adb_shell(f"input swipe {x} {y} {x} {y} {duration}")
 
     def secure_adb_screencap(self) -> Image:
         result = NewImage(mode="RGB", size=(1, 1))

--- a/roktracker/utils/exceptions.py
+++ b/roktracker/utils/exceptions.py
@@ -4,3 +4,7 @@ class AdbError(RuntimeError):
 
 class ConfigError(RuntimeError):
     pass
+
+
+class GovernorNotFoundError(RuntimeError):
+    pass

--- a/roktracker/utils/general.py
+++ b/roktracker/utils/general.py
@@ -72,7 +72,7 @@ def is_string_float(element: str, allow_empty=False) -> bool:
         return False
 
 def more_info_present(ocr_text: str) -> bool:
-    return "MoreInfo" in ocr_text or "Morenfor" in ocr_text
+    return "MoreInfo" in ocr_text or "Moren" in ocr_text
 
 def generate_random_id(length: int) -> str:
     alphabet = string.ascii_lowercase + string.digits
@@ -88,7 +88,9 @@ def random_delay() -> float:
 
 
 def wait_random_range(min_time: float, max_offset: float) -> None:
-    time.sleep(random.uniform(min_time, min_time + max_offset))
+    # Occasionally add a longer human-like pause (roughly 1 in 20 calls)
+    extra = random.uniform(1.5, 4.0) if random.random() < 0.05 else 0.0
+    time.sleep(random.uniform(min_time, min_time + max_offset) + extra)
 
 
 def format_timedelta_to_HHMMSS(td: datetime.timedelta) -> str:


### PR DESCRIPTION
## Problem

After a Rise of Kingdoms UI update, the kingdom scanner could no longer detect the governor profile as open. The `More Info` button check was silently failing because:

- The default Tesseract PSM mode returned empty output on the small (137x29px) region
- `PSM.SINGLE_LINE` returns `Morenfo` which was not matched by the old check for `Morenfor`

Additionally, the scanner used `input tap` (instantaneous) with exact pixel coordinates, which is easy to detect as automated behaviour.

## Changes

**`roktracker/kingdom/scanner.py`**
- Use `PSM.SINGLE_LINE` for the More Info button OCR check
- Add `GovernorNotFoundError` with a clear message when the game is not on the rankings screen instead of crashing with `KeyError: 'power'`
- Replace direct `input tap` shell calls with `secure_adb_tap` (consistent jitter + press duration)

**`roktracker/utils/general.py`**
- `more_info_present`: check for `Moren` prefix instead of exact `Morenfor` to handle OCR variants
- `wait_random_range`: add occasional random pause (1.5–4s, ~5% chance) to break regular timing patterns

**`roktracker/utils/adb.py`**
- `secure_adb_tap`: add ±5px random jitter and 50–150ms press duration using `input swipe` instead of `input tap`

**`roktracker/utils/exceptions.py`**
- Add `GovernorNotFoundError`

## Test

Tested on Bluestacks with the new Governor Profile UI. Scanner now correctly detects the open profile and proceeds with the scan.