### PR TITLE
fixed scan for lightning eagle theme

### DIFF
--- a/roktracker/kingdom/scanner.py
+++ b/roktracker/kingdom/scanner.py
@@ -273,21 +273,23 @@ class KingdomScanner:
             else:
                 gov_info = True
                 image_check = load_cv2_img(
-                    self.img_path / "check_more_info.png", cv2.IMREAD_GRAYSCALE
+                    self.img_path / "check_more_info.png", cv2.IMREAD_COLOR_BGR
                 )
 
                 # Checking for more info
                 im_check_more_info = cropToRegion(
                     image_check, rok_ui.ocr_check_profile_version
                 )
+                im_check_more_info = advancedProcessing(im_check_more_info, 3, "dimmed white")
+
                 check_profile_version = ""
 
                 with PyTessBaseAPI(path=str(self.tesseract_path)) as api:
-                    api.SetVariable("tessedit_char_whitelist", "Aclaim")
+                    api.SetVariable("tessedit_char_whitelist", "Civlzaton")
                     api.SetImage(Image.fromarray(im_check_more_info))  # type: ignore (pylance is messed up)
                     check_profile_version = api.GetUTF8Text()
 
-                if "Acclaim" in check_profile_version:
+                if "Civilization" in check_profile_version:
                     ui_positions = rok_ui.ocr_regions
                     tap_positions = rok_ui.tap_positions
                 else:
@@ -329,7 +331,7 @@ class KingdomScanner:
             ) as api:
                 if self.scan_options["Power"]:
                     im_gov_power = cropToRegion(image, ui_positions["power"])
-                    im_gov_power_bw = preprocessImage(im_gov_power, 3, 100, 12, True)
+                    im_gov_power_bw = advancedProcessing(im_gov_power, 3, "white")
 
                     governor_data.power = ocr_number(api, im_gov_power_bw)
 
@@ -337,8 +339,8 @@ class KingdomScanner:
                     im_gov_killpoints = cropToRegion(
                         image, ui_positions["killpoints"]
                     )
-                    im_gov_killpoints_bw = preprocessImage(
-                        im_gov_killpoints, 3, 100, 12, True
+                    im_gov_killpoints_bw = advancedProcessing(
+                        im_gov_killpoints, 3, "white"
                     )
 
                     governor_data.killpoints = ocr_number(api, im_gov_killpoints_bw)

--- a/roktracker/utils/ocr.py
+++ b/roktracker/utils/ocr.py
@@ -5,6 +5,8 @@ import tesserocr
 from PIL import Image
 from cv2.typing import MatLike
 from typing import Tuple
+from typing import Literal
+import numpy as np
 
 
 def cropToRegion(image: MatLike, roi: Tuple[int, int, int, int]) -> MatLike:
@@ -43,6 +45,32 @@ def preprocessImage(
     (thresh, im_bw) = cv2.threshold(im_gray, threshold, 255, cv2.THRESH_BINARY)
     im_bw = cropToTextWithBorder(im_bw, border_size)
     return im_bw
+
+def advancedProcessing(
+        image: MatLike,
+        scale_factor: int,
+        mode: Literal["white", "dimmed white", "black"]
+) -> MatLike:
+    kernel = np.ones((2,2),np.uint8)
+    im_big = cv2.resize(image, (0, 0), fx=scale_factor, fy=scale_factor)
+    hsv = cv2.cvtColor(im_big, cv2.COLOR_BGR2HSV)
+
+    match mode:
+        case "black":
+            lower = np.array([0, 0, 0]) # Acclaim and ID
+            upper = np.array([255, 255, 30]) # Acclaim and ID
+        case "dimmed white":
+            lower = np.array([0, 0, 210]) # Acclaim and ID
+            upper = np.array([255, 255, 255]) # Acclaim and ID
+        case "white":
+            lower = np.array([0, 0, 220]) # Acclaim and ID
+            upper = np.array([255, 255, 255]) # Acclaim and ID
+        
+
+    mask = cv2.inRange(hsv, lower, upper)
+    result = cv2.dilate(mask,kernel,iterations = 1)
+    result = cv2.bitwise_not(result) # Need to invert to make text black
+    return result
 
 
 def ocr_number(api, image: MatLike):

--- a/roktracker/utils/rok_ui_positions.py
+++ b/roktracker/utils/rok_ui_positions.py
@@ -1,4 +1,5 @@
-ocr_check_profile_version = (877, 356, 85, 26)  # new profile UI has "Acclaim" text here
+#ocr_check_profile_version = (877, 356, 85, 26)  # new profile UI has "Acclaim" text here
+ocr_check_profile_version = (588, 356, 116, 26)  # new profile UI has "Civilization" text here
 
 # format: (x, y, width, height)
 ocr_regions_old = {


### PR DESCRIPTION
Fixes stuck scanner when Lightning Eagle theme gets encountered.
The scanner now uses an HSV mask instead of grayscale thresholding to read power, kill points, and the profile version check.
Also switch text to determine profile version.